### PR TITLE
Feature/load system opengl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,8 @@
 					<environmentVariables>
 						<PATH>${java.library.path}${path.separator}${vtk.lib.path}</PATH>
 						<LD_LIBRARY_PATH>${vtk.lib.path}${path.separator}$LD_LIBRARY_PATH</LD_LIBRARY_PATH>
-						<DYLD_LIBRARY_PATH>${vtk.lib.path}${path.separator}$DYLD_LIBRARY_PATH</DYLD_LIBRARY_PATH>
+						<DYLD_LIBRARY_PATH>${vtk.lib.path}${path.separator}$DYLD_LIBRARY_PATH</DYLD_LIBRARY_PATH> 
+						<!-- <DYLD_LIBRARY_PATH>${java.library.path}${path.separator}${vtk.lib.path}</DYLD_LIBRARY_PATH> -->
 					</environmentVariables>
 
 					<!-- DISABLE PARALLEL TEST OTHERWISE CANVAS DO NOT UPDATE PROPERLY (?!) 

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
 				<configuration>
 					
 					<!-- Required from CLI, but failing IDE -->
-					<argLine>-Djava.library.path=${vtk.lib.path}</argLine>
+					<!-- <argLine>-Djava.library.path=${vtk.lib.path}</argLine>-->
 
 					<includes>
 						<include>**/Test*.java</include>
@@ -210,12 +210,12 @@
 						<exclude>**/ITTest*.java</exclude>
 					</excludes>-->
 
-					
+					<!-- This forks the JVM for each test to ensure DLL are unloaded -->
 					<forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
 
 					<environmentVariables>
-						<PATH>$PATH${path.separator}${vtk.lib.path}</PATH>
+						<PATH>${java.library.path}${path.separator}${vtk.lib.path}</PATH>
 						<LD_LIBRARY_PATH>${vtk.lib.path}${path.separator}$LD_LIBRARY_PATH</LD_LIBRARY_PATH>
 						<DYLD_LIBRARY_PATH>${vtk.lib.path}${path.separator}$DYLD_LIBRARY_PATH</DYLD_LIBRARY_PATH>
 					</environmentVariables>

--- a/src/main/java/vtk/VTKUtils.java
+++ b/src/main/java/vtk/VTKUtils.java
@@ -39,6 +39,7 @@ public class VTKUtils {
       printEnv("DYLD_LIBRARY_PATH", ":");
     }
     else if(os.isUnix()) {
+      printEnv("PATH", ":");
       printEnv("LD_LIBRARY_PATH", ":");
     }
     else if(os.isWindows()) {
@@ -176,7 +177,7 @@ public class VTKUtils {
     }
     
     if(!found) {
-      System.out.println("Undefined environment variable " + var);
+      System.out.println(var + " : not found in the environment variable lists");
     }
   }
 

--- a/src/main/java/vtk/VTKUtils.java
+++ b/src/main/java/vtk/VTKUtils.java
@@ -3,6 +3,8 @@ package vtk;
 import java.io.File;
 import java.util.Map;
 import org.jzy3d.os.OperatingSystem;
+import vtk.rendering.jogl.Environment;
+import vtk.rendering.jogl.OS;
 
 public class VTKUtils {
 
@@ -21,29 +23,50 @@ public class VTKUtils {
     
     
     if(!loadVtkNativeLibraries(null)){
-      System.out.println("Current -Djava.library.path=" + System.getProperty("java.library.path"));
       System.out.println("Suggest -Djava.library.path=" + absolutePath);
-      
-      OperatingSystem os = new OperatingSystem();
-
-
-      if(os.isMac()) {
-        printEnv("PATH", ":");
-        printEnv("DYLD_LIBRARY_PATH", ":");
-      }
-      else if(os.isUnix()) {
-        printEnv("LD_LIBRARY_PATH", ":");
-      }
-      else if(os.isWindows()) {
-        printEnv("PATH", ";");
-      }
-      else {
-        System.out.println("Undetected OS !!");
-      }
-      
-      System.out.println(os);
-      
+      pathConfigurationReport();
     }
+  }
+
+  public static void pathConfigurationReport() {
+    System.out.println("Current -Djava.library.path=" + System.getProperty("java.library.path"));
+    
+    OperatingSystem os = new OperatingSystem();
+
+
+    if(os.isMac()) {
+      printEnv("PATH", ":");
+      printEnv("DYLD_LIBRARY_PATH", ":");
+    }
+    else if(os.isUnix()) {
+      printEnv("LD_LIBRARY_PATH", ":");
+    }
+    else if(os.isWindows()) {
+      printEnv("PATH", ";");
+    }
+    else {
+      System.out.println("Undetected OS !!");
+    }
+    
+    System.out.println(os);
+  }
+  
+  protected static void appendSystemPathToJavaLibPath() {
+    String javaLibPathKey = "java.library.path";
+    String javaLibraryPath = System.getProperty(javaLibPathKey);
+
+    System.err.println("=========================");
+    System.err.println("Now " + javaLibPathKey + "=" + javaLibraryPath);
+    System.err.println(" ");
+
+    if(OS.isWindows()) {
+      Environment env = new Environment();
+      env.get("PATH");
+      javaLibraryPath += File.pathSeparator + env.get("PATH");
+      System.setProperty(javaLibPathKey, javaLibraryPath);
+      System.err.println("Now " + javaLibPathKey + "=" + javaLibraryPath);
+    }
+    System.err.println("=========================");
   }
 
   /**

--- a/src/main/java/vtk/rendering/jogl/Environment.java
+++ b/src/main/java/vtk/rendering/jogl/Environment.java
@@ -144,7 +144,7 @@ public class Environment {
     }
 
     if (!found) {
-      System.out.println("Undefined environment variable \"" + var + "\"");
+      System.out.println(var + " was not found in the environment variable lists");
     }
   }
 

--- a/src/main/java/vtk/rendering/jogl/OS.java
+++ b/src/main/java/vtk/rendering/jogl/OS.java
@@ -2,16 +2,19 @@ package vtk.rendering.jogl;
 
 public class OS {
   public static boolean isWindows() {
-    return System.getProperty("os.name").toLowerCase().indexOf("win") >= 0;
+    return name().indexOf("win") >= 0;
   }
   
   public static boolean isUnix() {
-    String name = System.getProperty("os.name").toLowerCase();
+    String name = name();
     return (name.indexOf("nix") >= 0 || name.indexOf("nux") >= 0 || name.indexOf("aix") > 0);
   }
   
   public static boolean isMac() {
-    return System.getProperty("os.name").toLowerCase().indexOf("mac") >= 0;
+    return name().indexOf("mac") >= 0;
   }
 
+  public static String name() {
+    return System.getProperty("os.name").toLowerCase();
+  }
 }

--- a/src/main/java/vtk/rendering/jogl/VTKVersatileCanvas.java
+++ b/src/main/java/vtk/rendering/jogl/VTKVersatileCanvas.java
@@ -1,5 +1,6 @@
 package vtk.rendering.jogl;
 
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +26,11 @@ import vtk.rendering.jogl.chip.stat.ChipSelectorStatic;
 public class VTKVersatileCanvas {
   public static void loadNativesFor(Chip chip) {
     defaultChip = chip;
-
+    
+    // Ensure lib path contains the path (limitation in maven when invoking System.loadLibrary("opengl32")
+    //appendSystemPathToJavaLibPath();
+    
+    // Select chip
     ChipSelector selector = new ChipSelector();
     selector.use(chip);
     
@@ -39,6 +44,8 @@ public class VTKVersatileCanvas {
 
     VTKUtils.loadVtkNativeLibraries();
   }
+
+  
   
 
   protected static Chip defaultChip;

--- a/src/main/java/vtk/rendering/jogl/chip/ChipSelector.java
+++ b/src/main/java/vtk/rendering/jogl/chip/ChipSelector.java
@@ -79,14 +79,10 @@ public class ChipSelector {
   public static final String OPENGL_LIB_PATH_WINDOWS_PROPERTY_NAME = "opengl.windows.path";
   public static final String OPENGL_LIB_PATH_MACOS_PROPERTY_NAME = "opengl.macos.path";
 
-  // protected static final String OPENGL_SYSTEM_PATH_MACOS_DEFAULT =
-  // "/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/";
-  // protected static final String OPENGL_SYSTEM_PATH_WINDOWS_DEFAULT = "C:\\Windows\\System32\\";
 
+  protected static String OPENGL_LIB_MACOS = "GL"; // libGL.dylib
+  protected static String OPENGL_LIB_WINDOWS = "opengl32"; // opengl32.dll
 
-  protected static String OPENGL_LIB_MACOS = "libGL.dylib";
-  protected static String OPENGL_LIB_WINDOWS = "opengl32";
-  
 
   protected static Logger log = LogManager.getLogger(ChipSelector.class);
 
@@ -96,7 +92,6 @@ public class ChipSelector {
   protected String mesaPath = "";
   protected String openglPathWindows = "";
   protected String openglPathMacOS = "";
-  protected boolean debug = false;
 
 
 
@@ -151,20 +146,32 @@ public class ChipSelector {
   protected static String getOpenGLPathWindows() {
     String path = System.getProperty(OPENGL_LIB_PATH_WINDOWS_PROPERTY_NAME);
 
-    if (path != null && !"".equals(path))
+    if (isDefined(path))
       return path;
     else
       return null;
   }
+  
+  //protected static final String OPENGL_SYSTEM_PATH_WINDOWS_DEFAULT = "C:\\Windows\\System32\\";
+
 
   protected static String getOpenGLPathMacOS() {
     String path = System.getProperty(OPENGL_LIB_PATH_MACOS_PROPERTY_NAME);
 
-    if (path != null && !"".equals(path))
+    if (isDefined(path))
       return path;
     else
       return null;
   }
+  
+  protected static final String OPENGL_SYSTEM_PATH_MACOS_DEFAULT =
+  "/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/";
+
+  /*****************************************************/
+  /**                                                  */
+  /** CHIP SELECT API */
+  /**                                                  */
+  /*****************************************************/
 
 
 
@@ -255,7 +262,7 @@ public class ChipSelector {
       log.debug(
           MESA_CPU_RENDERING_ENV_VAR + " is now set to " + env.get(MESA_CPU_RENDERING_ENV_VAR));
 
-      loadOpenGLMac_System();
+      //loadOpenGLMac_System();
 
     }
 
@@ -274,8 +281,13 @@ public class ChipSelector {
       log.debug("Try loading MacOS System GL by fullpath : " + path);
       System.load(path);
     } else {
+      // Not working yet
       log.debug("Try loading MacOS System GL by name : " + OPENGL_LIB_MACOS);
       System.loadLibrary(OPENGL_LIB_MACOS);
+
+      // fallback on explicit default path
+      //String defaultPath = getPathAndLibWithSeparator(OPENGL_SYSTEM_PATH_MACOS_DEFAULT, System.mapLibraryName(OPENGL_LIB_MACOS));
+      //System.load(defaultPath);
     }
   }
 
@@ -288,7 +300,7 @@ public class ChipSelector {
   protected String getOpenGLPath_MacOS_System() {
     // if a system path is given, returns a full path
     if (openglPathMacOS != null) {
-      return getPathAndLibWithSeparator(openglPathMacOS, OPENGL_LIB_MACOS);
+      return getPathAndLibWithSeparator(openglPathMacOS, System.mapLibraryName(OPENGL_LIB_MACOS));
     }
     // otherwise null to load lib by name
     else {
@@ -297,7 +309,7 @@ public class ChipSelector {
   }
 
   protected String getOpenGLPath_MacOS_Mesa() {
-    return getPathAndLibWithSeparator(mesaPath, OPENGL_LIB_MACOS);
+    return getPathAndLibWithSeparator(mesaPath, System.mapLibraryName(OPENGL_LIB_MACOS));
   }
 
   /*****************************************************/
@@ -359,11 +371,10 @@ public class ChipSelector {
       System.load(path);
     } else {
       log.debug("Try loading Windows GL by name : " + OPENGL_LIB_WINDOWS);
-      
+
       try {
-        System.loadLibrary(OPENGL_LIB_WINDOWS);        
-      }
-      catch(Exception e) {
+        System.loadLibrary(OPENGL_LIB_WINDOWS);
+      } catch (Exception e) {
         e.printStackTrace();
         VTKUtils.pathConfigurationReport();
         throw e;
@@ -379,7 +390,8 @@ public class ChipSelector {
 
   protected String getOpenGLPath_Windows_System() {
     if (openglPathWindows != null) {
-      return getPathAndLibWithSeparator(openglPathWindows, System.mapLibraryName(OPENGL_LIB_WINDOWS));
+      return getPathAndLibWithSeparator(openglPathWindows,
+          System.mapLibraryName(OPENGL_LIB_WINDOWS));
     } else {
       return null;
     }
@@ -391,8 +403,8 @@ public class ChipSelector {
 
   /*****************************************************/
 
-  protected boolean isDefined(String path) {
-    return path!= null && !"".equals(path);
+  protected static boolean isDefined(String path) {
+    return path != null && !"".equals(path);
   }
 
   protected String getPathAndLibWithSeparator(String path, String libName) {

--- a/src/test/java/log4j.properties
+++ b/src/test/java/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=DEBUG, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/src/test/java/vtk/rendering/jogl/TestVersatileCanvas_CPU.java
+++ b/src/test/java/vtk/rendering/jogl/TestVersatileCanvas_CPU.java
@@ -9,7 +9,8 @@ import vtk.rendering.jogl.chip.Chip;
  * 
  * Limitations
  * <ul>
- * <li>this test may fail on Windows if the executing JVM already executed {@link TestVersatileCanvas_GPU}
+ * <li>this test may fail on Windows if the executing JVM already executed {@link TestVersatileCanvas_GPU}. Maven Surefire configuration ensure a new JVM is forked for each
+ * test, but the IDE will probably not apply this setting.
  * </ul>
  * 
  * @author Martin Pernollet

--- a/src/test/java/vtk/rendering/jogl/TestVersatileCanvas_GPU.java
+++ b/src/test/java/vtk/rendering/jogl/TestVersatileCanvas_GPU.java
@@ -9,7 +9,9 @@ import vtk.rendering.jogl.chip.Chip;
  * 
  * Limitations
  * <ul>
- * <li>this test may fail on Windows if the executing JVM already executed {@link TestVersatileCanvas_CPU}
+ * <li>this test may fail on Windows if the executing JVM already executed
+ * {@link TestVersatileCanvas_CPU}. Maven Surefire configuration ensure a new JVM is forked for each
+ * test, but the IDE will probably not apply this setting.
  * </ul>
  * 
  * <h2>MacOS IDE configuration</h2>
@@ -17,29 +19,27 @@ import vtk.rendering.jogl.chip.Chip;
  * 
  * @author Martin Pernollet
  */
-public class TestVersatileCanvas_GPU extends TestVersatileCanvas{
- 
+public class TestVersatileCanvas_GPU extends TestVersatileCanvas {
+
   @BeforeClass
   public static void load() {
     configureMesaPathProperty();
 
-    //System.out.println("LOADING NATIVE / GPU");
-    VTKVersatileCanvas.loadNativesFor(Chip.GPU);    
+    // System.out.println("LOADING NATIVE / GPU");
+    VTKVersatileCanvas.loadNativesFor(Chip.GPU);
   }
-  
+
   @Test
   public void whenQueryGPU_ThenGPUIsUsed() throws InterruptedException {
-    Chip chip = Chip.GPU;
-    
-  
+
     VTKVersatileCanvas canvas = new VTKVersatileCanvas();
-    
- // Embedding GUI with auto-reload hability    
+
+    // Embedding GUI with auto-reload hability
     frame = newSceneAndFrame(canvas);
-    
+
     Thread.sleep(1000);
-    
-    Assert.assertEquals(chip, canvas.getQueriedChip());
-    Assert.assertEquals(chip, canvas.getActualChip());
+
+    Assert.assertEquals(Chip.GPU, canvas.getQueriedChip());
+    Assert.assertEquals(Chip.GPU, canvas.getActualChip());
   }
 }

--- a/src/test/java/vtk/rendering/jogl/chip/TestChipSelector.java
+++ b/src/test/java/vtk/rendering/jogl/chip/TestChipSelector.java
@@ -260,7 +260,7 @@ public class TestChipSelector {
   @Test
   public void whenConfigureGLSystemPath_ThenFullPathIsProperlyConfigure_Windows() {
     if(!OS.isWindows()) {
-      System.err.println("Do not execute this test for windows");
+      System.err.println(TEST_ON_WINDOWS_BYPASSED);
       return;
     }
     

--- a/src/test/java/vtk/rendering/jogl/chip/TestChipSelector.java
+++ b/src/test/java/vtk/rendering/jogl/chip/TestChipSelector.java
@@ -29,7 +29,7 @@ public class TestChipSelector {
     if(brew1!=null)
       return brew1;
     
-    // try homebrew 1
+    // try homebrew 2
     File brew2 = detectHomebrewInstall("/opt/local/Cellar/mesa");
     if(brew2!=null)
       return brew2;
@@ -39,12 +39,15 @@ public class TestChipSelector {
 
   private static File detectHomebrewInstall(String homebrew) {
     File homebrew1 = new File(homebrew);
-    File brewMesa = null;
+    
+    if(!homebrew1.exists())
+      return null;
+    
     if(homebrew1.listFiles().length>=1) {
       File v1 = homebrew1.listFiles()[0];
-      brewMesa = new File(v1.getAbsolutePath()+ "/lib/");
+      return new File(v1.getAbsolutePath()+ "/lib/");
     }
-    return brewMesa;
+    return null;
   }
 
   ////////////////////////////////////////////////////////

--- a/src/test/java/vtk/rendering/jogl/chip/TestChipSelector.java
+++ b/src/test/java/vtk/rendering/jogl/chip/TestChipSelector.java
@@ -3,6 +3,7 @@ package vtk.rendering.jogl.chip;
 import java.io.File;
 import org.junit.Assert;
 import org.junit.Test;
+import vtk.VTKUtils;
 import vtk.rendering.jogl.Environment;
 import vtk.rendering.jogl.OS;
 
@@ -15,7 +16,36 @@ public class TestChipSelector {
   private static final String MACOS_MESA_PATH_RELATIVE = ".\\lib\\9.1.0\\mesa-Darwin-x86_64";
 
   public static final File WINDOWS_MESA_PATH = new File(WINDOWS_MESA_PATH_RELATIVE);
-  public static final File MACOS_MESA_PATH = new File(MACOS_MESA_PATH_RELATIVE);
+  public static final File MACOS_MESA_PATH = detectMesaMacOS();
+  
+  public static File detectMesaMacOS() {
+    File local = new File(MACOS_MESA_PATH_RELATIVE);
+    
+    if(local.exists())
+      return local;
+    
+    // try homebrew 1
+    File brew1 = detectHomebrewInstall("/opt/homebrew/Cellar/mesa");
+    if(brew1!=null)
+      return brew1;
+    
+    // try homebrew 1
+    File brew2 = detectHomebrewInstall("/opt/local/Cellar/mesa");
+    if(brew2!=null)
+      return brew2;
+    
+    return null;
+  }
+
+  private static File detectHomebrewInstall(String homebrew) {
+    File homebrew1 = new File(homebrew);
+    File brewMesa = null;
+    if(homebrew1.listFiles().length>=1) {
+      File v1 = homebrew1.listFiles()[0];
+      brewMesa = new File(v1.getAbsolutePath()+ "/lib/");
+    }
+    return brewMesa;
+  }
 
   ////////////////////////////////////////////////////////
   //
@@ -72,8 +102,10 @@ public class TestChipSelector {
       System.err.println(TEST_ON_MACOS_BYPASSED);
       return;
     }
+    
+    VTKUtils.pathConfigurationReport();
 
-    ChipSelector selector = new ChipSelector();
+    ChipSelector selector = new ChipSelector(MACOS_MESA_PATH.getAbsolutePath(), null, null);
 
     // When using CPU, Mesa env variable is set for CPU rendering
     selector.use(Chip.CPU);


### PR DESCRIPTION
- Let ChipSelector load operating system OpenGL library by its name rather than by an explicit path that may require modification.
- Keep the ability to define an explicit path through opengl.windows.path
- MacOS is not MESA enabled for now. ChipSelector will simply do nothing when trying to load GPU.